### PR TITLE
Add thread-safe static cache for ConfigFile instances

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@
 .vsconfig
 Player/
 /[Aa]ssets/Plugins/CoreKeeper*
-/[Aa]ssets/Plugins/CoreKeeperModSDK*
 /[Aa]ssets/CK*
 
 /[Ll]ibrary/

--- a/Assets/Plugins/CoreKeeper.meta
+++ b/Assets/Plugins/CoreKeeper.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 233066a4ebd35a44a80b2f62373975f9
+guid: 4370e215b4a8f554489395e491c34e89
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}


### PR DESCRIPTION
Why am I opening this PR?
I'm developing a mod to display a dynamic UI based on mod .cfg files. For that I need to access the fully initialized ConfigFiles for each mod and can't rely on the "Orphan Entries" created, when accessing it as third-party with the current implementation.

- Introduced a static list `AllConfigFiles` to cache all `ConfigFile` instances created during runtime.
- Exposed a read-only `AllConfigFilesReadOnly` property of type `IReadOnlyList<ConfigFile>` for external read-only access.
- Synchronized all access to `AllConfigFiles` using a dedicated `lock` object (`LockObject`) to ensure thread safety.
- Ensured consistent access to the `AllConfigFiles` collection, preventing race conditions and concurrent modification issues.
- Updated XML documentation to reflect changes and provide additional usage guidelines for `AllConfigFilesReadOnly`.